### PR TITLE
NightMode Styling

### DIFF
--- a/src/templates/stylesheet.css
+++ b/src/templates/stylesheet.css
@@ -13,12 +13,18 @@ img {
     height: 100px;
     width: 100px;
 }
+
 .box {
     width: 320px;
     height: 350px;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .2), 0 1px 5px 0 rgba(0, 0, 0, .12);
     margin: auto;
 }
+
+.nightMode .box {
+    box-shadow: 0 2px 2px 0 rgba(255, 255, 255, .5), 0 3px 1px -2px rgba(255, 255, 255, .2), 0 1px 5px 0 rgba(255, 255, 255, .5);
+}
+
 .box_title {
     background: #ffecb3;
     padding: 16px;
@@ -42,11 +48,21 @@ img {
     padding: 16px;
     width: 90%
 }
+
 .box_text h2 {
     margin: 0 0 10px 0;
     color: rgba(0, 0, 0, .7);
     font-family: "Roboto Slab";
 }
+
+.nightMode .box_text {
+    color: rgba(255, 255, 255, .7);
+}
+
+.nightMode .box_text h2 {
+    color: rgba(255, 255, 255, .9);
+}
+
 
 .periodic {
   display: inline-block;

--- a/src/templates/stylesheet.css
+++ b/src/templates/stylesheet.css
@@ -1,6 +1,11 @@
 .card {
     font-family: "Roboto";
 }
+
+.card.nightMode{
+    background-color: rgba(33, 33, 33, 1);
+}
+
 .picture {
     height: 100px;
     width: 100px;
@@ -30,6 +35,11 @@ img {
     padding: 16px;
     text-align: center;
 }
+
+.nightMode .box_title{
+   background: #888;
+}
+
 .box_title_text {
     color: rgba(0, 0, 0, 1);
     font-size: 24px;
@@ -37,6 +47,15 @@ img {
     margin: 0;
     min-height: 35px;
 }
+
+.nightMode .box_title_text{
+   color: #FFFFFF;
+}
+
+.nightMode .box_title_text sub{
+   color: #FFFFFF;
+}
+
 .box_title_text sub {
     color: rgba(0, 0, 0, 0.7);
 }


### PR DESCRIPTION
Anki 2.1.20 recently added a native NightMode setting in the config. It works by automatically inveryting most colors, however it seems to not work for specifically set rgba values, tho it provides a ".nightMode" override for the css to handle things like that. 

This PR contains the styling necessary to have all things be visible in that mode. I tweeked the alpha variables a bit to what looks good to me personally, feel free to change it of course 👍